### PR TITLE
feat: format the default output of misspell into a codeclimate report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
             ./Taskfile.yaml
             ./.github/workflows/**
             ./CODE_OF_CONDUCT.md
+            ./internal/misspell/report_test.go
 
       - name: Code Coverage
         if: matrix.os == 'ubuntu-latest'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,7 +33,7 @@ tasks:
   test:
     desc: Run the tests
     cmds:
-      - go test -race -vet=off -p 1 -covermode=atomic -coverprofile=unittest.out ./...
+      - go test -race -vet=off -p 1 -covermode=atomic -coverprofile=coverage.out ./...
 
   lint:
     desc: Lint the code using golangci

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,33 +24,13 @@ package cmd
 
 import (
 	ctx "context"
-	"crypto/md5"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"strconv"
-	"strings"
 
+	"github.com/purpleclay/misspell-codeclimate/internal/misspell"
 	"github.com/spf13/cobra"
 )
-
-type codeClimateEntry struct {
-	Description string               `json:"description"`
-	Fingerprint string               `json:"fingerprint"`
-	Severity    string               `json:"severity"`
-	Location    codeQualityViolation `json:"location"`
-}
-
-type codeQualityViolation struct {
-	Path  string                       `json:"path"`
-	Lines codeQualityViolationPosition `json:"lines"`
-}
-
-type codeQualityViolationPosition struct {
-	Begin int `json:"begin"`
-}
 
 type options struct {
 	ReportFile string
@@ -64,57 +44,27 @@ func Execute(out io.Writer) error {
 		Short:        "Turn that misspell report into a GitLab compatible codeclimate report",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return transformReport(opt, out)
+			report, err := misspell.ParseReport(opt.ReportFile)
+			if err != nil {
+				return err
+			}
+
+			data, err := json.Marshal(report)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out, string(data))
+			return nil
 		},
 	}
 
-	rootCmd.Flags().StringVar(&opt.ReportFile, "f", "", "Path to the misspell report to parse")
+	rootCmd.Flags().StringVar(&opt.ReportFile, "file", "", "Path to the misspell report to parse")
+	rootCmd.MarkFlagRequired("file")
 
 	rootCmd.AddCommand(newVersionCmd(out))
 	rootCmd.AddCommand(newManPagesCmd(out))
 	rootCmd.AddCommand(newCompletionCmd(out))
 
 	return rootCmd.ExecuteContext(ctx.Background())
-}
-
-func transformReport(opt options, out io.Writer) error {
-	report, err := ioutil.ReadFile(opt.ReportFile)
-	if err != nil {
-		return err
-	}
-
-	// Split the report by new line and process each line in turn
-	lines := strings.Split(string(report), "\n")
-
-	entries := make([]codeClimateEntry, 0, len(lines))
-
-	// Split on the content of the report and process each line at a time
-	for _, line := range lines {
-		parts := strings.Split(line, ":")
-		if len(parts) != 4 {
-			return errors.New("unsupported misspell report line, expecting report in default format")
-		}
-
-		violationPos, _ := strconv.Atoi(parts[1])
-
-		entries = append(entries, codeClimateEntry{
-			Description: parts[3],
-			Fingerprint: fmt.Sprintf("%x", md5.Sum([]byte(line))),
-			Severity:    "minor",
-			Location: codeQualityViolation{
-				Path: parts[0],
-				Lines: codeQualityViolationPosition{
-					Begin: violationPos,
-				},
-			},
-		})
-	}
-
-	data, err := json.Marshal(entries)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintln(out, string(data))
-	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,23 +24,97 @@ package cmd
 
 import (
 	ctx "context"
+	"crypto/md5"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
+type codeClimateEntry struct {
+	Description string               `json:"description"`
+	Fingerprint string               `json:"fingerprint"`
+	Severity    string               `json:"severity"`
+	Location    codeQualityViolation `json:"location"`
+}
+
+type codeQualityViolation struct {
+	Path  string                       `json:"path"`
+	Lines codeQualityViolationPosition `json:"lines"`
+}
+
+type codeQualityViolationPosition struct {
+	Begin int `json:"begin"`
+}
+
+type options struct {
+	ReportFile string
+}
+
 func Execute(out io.Writer) error {
+	opt := options{}
+
 	rootCmd := &cobra.Command{
-		Use:   "misspell-codeclimate",
-		Short: "Turn that misspell report into a GitLab compatible codeclimate report",
+		Use:          "misspell-codeclimate",
+		Short:        "Turn that misspell report into a GitLab compatible codeclimate report",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			return transformReport(opt, out)
 		},
 	}
+
+	rootCmd.Flags().StringVar(&opt.ReportFile, "f", "", "Path to the misspell report to parse")
 
 	rootCmd.AddCommand(newVersionCmd(out))
 	rootCmd.AddCommand(newManPagesCmd(out))
 	rootCmd.AddCommand(newCompletionCmd(out))
 
 	return rootCmd.ExecuteContext(ctx.Background())
+}
+
+func transformReport(opt options, out io.Writer) error {
+	report, err := ioutil.ReadFile(opt.ReportFile)
+	if err != nil {
+		return err
+	}
+
+	// Split the report by new line and process each line in turn
+	lines := strings.Split(string(report), "\n")
+
+	entries := make([]codeClimateEntry, 0, len(lines))
+
+	// Split on the content of the report and process each line at a time
+	for _, line := range lines {
+		parts := strings.Split(line, ":")
+		if len(parts) != 4 {
+			return errors.New("unsupported misspell report line, expecting report in default format")
+		}
+
+		violationPos, _ := strconv.Atoi(parts[1])
+
+		entries = append(entries, codeClimateEntry{
+			Description: parts[3],
+			Fingerprint: fmt.Sprintf("%x", md5.Sum([]byte(line))),
+			Severity:    "minor",
+			Location: codeQualityViolation{
+				Path: parts[0],
+				Lines: codeQualityViolationPosition{
+					Begin: violationPos,
+				},
+			},
+		})
+	}
+
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, string(data))
+	return nil
 }

--- a/internal/misspell/report.go
+++ b/internal/misspell/report.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2022 Purple Clay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package misspell
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// CodeClimateEntry ...
+type CodeClimateEntry struct {
+	Description string               `json:"description"`
+	Fingerprint string               `json:"fingerprint"`
+	Severity    string               `json:"severity"`
+	Location    CodeQualityViolation `json:"location"`
+}
+
+// CodeQualityViolation ...
+type CodeQualityViolation struct {
+	Path  string                       `json:"path"`
+	Lines CodeQualityViolationPosition `json:"lines"`
+}
+
+// CodeQualityViolationPosition ...
+type CodeQualityViolationPosition struct {
+	Begin int `json:"begin"`
+}
+
+// ParseReport ...
+func ParseReport(reportPath string) ([]CodeClimateEntry, error) {
+	report, err := ioutil.ReadFile(reportPath)
+	if err != nil {
+		return []CodeClimateEntry{}, err
+	}
+
+	// Split the report by new line and process each line in turn
+	lines := strings.Split(string(report), "\n")
+
+	entries := make([]CodeClimateEntry, 0, len(lines))
+
+	// Split on the content of the report and process each line at a time
+	for _, line := range lines {
+		parts := strings.Split(line, ":")
+		if len(parts) != 4 {
+			return []CodeClimateEntry{}, errors.New("unsupported misspell report line, expecting report in default format")
+		}
+
+		violationPos, _ := strconv.Atoi(parts[1])
+
+		entries = append(entries, CodeClimateEntry{
+			Description: strings.TrimSpace(parts[3]),
+			Fingerprint: fmt.Sprintf("%x", md5.Sum([]byte(line))),
+			Severity:    "minor",
+			Location: CodeQualityViolation{
+				Path: parts[0],
+				Lines: CodeQualityViolationPosition{
+					Begin: violationPos,
+				},
+			},
+		})
+	}
+
+	return entries, nil
+}

--- a/internal/misspell/report_test.go
+++ b/internal/misspell/report_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2022 Purple Clay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package misspell_test
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/purpleclay/misspell-codeclimate/internal/misspell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:misspell
+func TestParseReport(t *testing.T) {
+	line1 := `docs/README.md:1:14: "incorectly" is a misspelling of "incorrectly"`
+	line2 := `docs/test.txt:1:14: "incorectly" is a misspelling of "incorrectly"`
+	path := writeFile(t, fmt.Sprintf("%s\n%s", line1, line2))
+
+	report, err := misspell.ParseReport(path)
+	require.NoError(t, err)
+
+	require.Len(t, report, 2)
+	assert.Equal(t, `"incorectly" is a misspelling of "incorrectly"`, report[0].Description)
+	assert.Equal(t, fmt.Sprintf("%x", md5.Sum([]byte(line1))), report[0].Fingerprint)
+	assert.Equal(t, "minor", report[0].Severity)
+	assert.Equal(t, "docs/README.md", report[0].Location.Path)
+	assert.Equal(t, 1, report[0].Location.Lines.Begin)
+
+	assert.Equal(t, `"incorectly" is a misspelling of "incorrectly"`, report[1].Description)
+	assert.Equal(t, fmt.Sprintf("%x", md5.Sum([]byte(line2))), report[1].Fingerprint)
+	assert.Equal(t, "minor", report[1].Severity)
+	assert.Equal(t, "docs/test.txt", report[1].Location.Path)
+	assert.Equal(t, 1, report[1].Location.Lines.Begin)
+}
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "misspell-report.txt")
+
+	err := ioutil.WriteFile(f, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	return f
+}
+
+func TestParseReport_ReportNotFound(t *testing.T) {
+	_, err := misspell.ParseReport("unknown-report.txt")
+
+	assert.EqualError(t, err, "open unknown-report.txt: no such file or directory")
+}
+
+func TestParseReport_UnsupportedReportFormat(t *testing.T) {
+	path := writeFile(t, "unexpected format in report")
+
+	_, err := misspell.ParseReport(path)
+	assert.EqualError(t, err, "unsupported misspell report line, expecting report in default format")
+}


### PR DESCRIPTION
closes #2 